### PR TITLE
Fix typo for SR conversion source

### DIFF
--- a/Controllers/GeocodeServerController.cs
+++ b/Controllers/GeocodeServerController.cs
@@ -634,7 +634,7 @@ namespace GeoREST.Controllers
 
             if (this.queryParams.outSR != null && (x != 0 && y != 0))
             {
-                HttpWebRequest requestSR = WebRequest.CreateHttp("http://tasks.arcgisonline.com/ArcGIS/rest/services/Geometry/GeometryServer/project?inSR=4236&outSR=" + this.queryParams.outSR + "&f=json&geometries=" + x + "," + y);
+                HttpWebRequest requestSR = WebRequest.CreateHttp("http://tasks.arcgisonline.com/ArcGIS/rest/services/Geometry/GeometryServer/project?inSR=4326&outSR=" + this.queryParams.outSR + "&f=json&geometries=" + x + "," + y);
 
                 using (HttpWebResponse responseSR = requestSR.GetResponse() as HttpWebResponse)
                 {


### PR DESCRIPTION
SR conversion source should be 4326, not 4236, which resulted in
relatively small but significant errors in conversion.